### PR TITLE
Change capping-constraint schema

### DIFF
--- a/extensions/adobe/experience/offer-management/capping-constraint.description.md
+++ b/extensions/adobe/experience/offer-management/capping-constraint.description.md
@@ -1,0 +1,60 @@
+# Capping Constraint Schema
+
+```
+https://ns.adobe.com/experience/offer-management/capping-constraint
+```
+
+A capping constraint is a way of restricting how many times an offer is proposed. These restrictions can be applied in two ways.
+
+One of the ways is by setting a cap globally. This means that the offer won't be proposed more than the set cap. This is also referred to as volume-based capping.
+
+Another way is by setting a cap per profile. An offer is always proposed to some profile. A marketer may want to limit the number of times the same profile sees the offer. This is also referred to as user-fatigue capping.
+
+A marketer can set both these caps on an offer at the same time.
+
+
+| Abstract | Extensible | Status | Custom Properties | Additional Properties | Defined In |
+|----------|------------|--------|-------------------|-----------------------|------------|
+| Can be instantiated | Yes | Experimental | Forbidden | Permitted | [experience/offer-management/capping-constraint.json](experience/offer-management/capping-constraint.json) |
+
+## Capping Constraint Example
+```json
+{
+  "xdm:globalCap": 5000,
+  "xdm:profileCap": 3
+}
+```
+
+# Capping Constraint Properties
+
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [xdm:globalCap](#xdmglobalcap) | `integer` | Optional | Capping Constraint (this schema) |
+| [xdm:profileCap](#xdmprofilecap) | `integer` | Optional | Capping Constraint (this schema) |
+| `*` | any | Additional | this schema *allows* additional properties |
+
+## xdm:globalCap
+
+Global cap is a constraint on how many times an offer can be proposed in totality.
+
+`xdm:globalCap`
+* is optional
+* type: `integer`
+* defined in this schema
+
+### xdm:globalCap Type
+
+`integer`
+
+## xdm:profileCap
+
+Profile cap is a constraint on how many times a particular offer can be proposed to a certain profile.
+
+`xdm:profileCap`
+* is optional
+* type: `integer`
+* defined in this schema
+
+### xdm:profileCap Type
+
+`integer`

--- a/extensions/adobe/experience/offer-management/capping-constraint.schema.json
+++ b/extensions/adobe/experience/offer-management/capping-constraint.schema.json
@@ -1,6 +1,6 @@
 {
   "meta:license": [
-    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
     "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
@@ -14,20 +14,17 @@
     "capping-constraint": {
       "type": "object",
       "properties": {
-        "xdm:volume": {
+        "xdm:globalCap": {
           "type": "integer",
-          "title": "Volume",
-          "description": "Total offer volume",
-          "multipleOf": 1,
+          "title": "Global Cap",
+          "description": "Global cap is a constraint on how many times an offer can be proposed in totality.",
           "minimum": 1
         },
-        "xdm:frequency": {
-          "type": "number",
-          "title": "Frequency",
-          "description": "Frequency per profile",
-          "multipleOf": 0.1,
-          "minimum": 0,
-          "maximum": 100
+        "xdm:profileCap": {
+          "type": "integer",
+          "title": "Profile Cap",
+          "description": "Profile cap is a constraint on how many times an offer can be proposed to a certain profile.",
+          "minimum": 1
         }
       }
     }

--- a/extensions/adobe/experience/offer-management/offer-category.schema.json
+++ b/extensions/adobe/experience/offer-management/offer-category.schema.json
@@ -31,12 +31,6 @@
           "type": "string",
           "title": "Expression",
           "description": "Tag rule"
-        },
-        "xdm:cappingConstraint": {
-          "$ref":
-            "https://ns.adobe.com/experience/offer-management/capping-constraint",
-          "title": "Capping Constraint",
-          "description": "Offer Capping Constraint"
         }
       }
     }


### PR DESCRIPTION
Reviewer: @dmitry-shkolnik, @jbeckert

As discussed with @dmitry-shkolnik , I have made some changes to the capping-constraint schema. Also, I confirmed with @jbeckert that having a capping-constraint for offer-category is out of scope (at least initially). So, that has been removed.
Feedback from Lars around capping-constraint schema has been incorporated.
